### PR TITLE
Copy Consul config into container filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ENV VAULT_VERSION 0.3.1
 ADD https://dl.bintray.com/mitchellh/vault/vault_${VAULT_VERSION}_linux_amd64.zip /tmp/vault.zip
 RUN cd /bin && unzip /tmp/vault.zip && chmod +x /bin/vault && rm /tmp/vault.zip
 
+RUN mkdir -p /config
+COPY config/*.hcl /config/
+
 EXPOSE 8200
 ENV VAULT_ADDR "http://127.0.0.1:8200"
 


### PR DESCRIPTION
README provides a docker run command which expects
the config to be at /consul/
